### PR TITLE
Do not build deprecated ffmpeg codec

### DIFF
--- a/msm8660.mk
+++ b/msm8660.mk
@@ -142,7 +142,6 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/media_profiles.xml:system/etc/media_profiles.xml
 
 PRODUCT_COPY_FILES += \
-    frameworks/av/media/libstagefright/data/media_codecs_ffmpeg.xml:system/etc/media_codecs_ffmpeg.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:system/etc/media_codecs_google_audio.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_telephony.xml:system/etc/media_codecs_google_telephony.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:system/etc/media_codecs_google_video.xml


### PR DESCRIPTION
FFMpeg codec has been deprecated.

https://github.com/CyanogenMod/android_frameworks_av/commit/b55b927a6ae2eb67676e26fae45c7d81f585d7ac
